### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM test/test-java:666
+FROM test/test-java:600
 
 RUN apk update && apk add openjdk8
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk


### PR DESCRIPTION
`test/test-java` changed recently. This pull request ensures you're using the latest version of the image and changes `test/test-java` to the latest tag: `600`

New base image: `test/test-java:600`